### PR TITLE
Fixed NPE for paymentRefund and probably for oneclickInit

### DIFF
--- a/Integration Examples/eAPI v1.8/java/eAPI-v18-connector/src/main/java/cz/monetplus/mips/eapi/v18/connector/entity/ApiBase.java
+++ b/Integration Examples/eAPI v1.8/java/eAPI-v18-connector/src/main/java/cz/monetplus/mips/eapi/v18/connector/entity/ApiBase.java
@@ -33,6 +33,12 @@ public abstract class ApiBase implements Serializable {
 		sb.append(value).append(SEP);
 	}
 
+	protected void add(StringBuilder sb, Long value) {
+		if (value != null) {
+			sb.append(value).append(SEP);
+		}
+	}
+
 	protected void add(StringBuilder sb, long value) {
 		sb.append(value).append(SEP);
 	}


### PR DESCRIPTION
Fixes NPE for full refund where `amount` is `null` and the sign method
```
	@Override
	public String toSign() {
		StringBuilder sb = new StringBuilder(); 
		add(sb, merchantId);
		add(sb, payId);
		add(sb, dttm);
		add(sb, amount);
		deleteLast(sb);
		return sb.toString();
	}
```
fails.

```
2020-08-03 23:59:37.839 E -- Failed: RuntimeException: cz.monetplus.mips.eapi.v18.service.MipsException: nativeAPI call for paymentRefund operation failed:  > MipsException: nativeAPI call for paymentRefund operation failed:  > NullPointerException: null
```